### PR TITLE
Update LDAP support for ldap3-0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,7 +304,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lber"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -314,14 +314,14 @@ dependencies = [
 
 [[package]]
 name = "ldap3"
-version = "0.4.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "lber 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lber 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -687,7 +687,7 @@ dependencies = [
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "csv 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.10.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "ldap3 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ldap3 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1181,8 +1181,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"
 "checksum lazycell 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ce12306c4739d86ee97c23139f3a34ddf0387bbf181bc7929d287025a8c3ef6b"
-"checksum lber 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9a641f60225ff5b53780d6af60f8efb7e4cb7452b84801dfb2bb30c0987b6bee"
-"checksum ldap3 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e17563a38b586f02538a92a89570f0915c9097e4797f314b8a93ac666ffc1fa5"
+"checksum lber 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b2ba3d9e03604fda60029cb5b2aa77bbcf8d7dd68a47592b3ff1f1df268c8d5e"
+"checksum ldap3 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "27295c0d7ea9b479420394e548d482091544382855d941f6d0c6752af4765b0b"
 "checksum libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)" = "30885bcb161cf67054244d10d4a7f4835ffd58773bc72e07d35fecf472295503"
 "checksum linked-hash-map 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7860ec297f7008ff7a1e3382d7f7e1dcd69efc94751a2284bafc3d013c2aa939"
 "checksum log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "880f77541efa6e5cc74e76910c9884d9859683118839d6a1dc3b11e63512565b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ uuid = { version = "0.4", features = ["use_std", "serde"] }
 # Optional dependencies that are activated by the various features
 argon2rs = { version = "0.2.5", optional = true }
 csv = { version = "0.15", optional = true }
-ldap3 = { version = "0.4.0", optional = true }
+ldap3 = { version = "0.5", optional = true }
 ring = { version = "0.11", optional = true } # rust-jwt has this as its dependency
 strfmt = { version = "0.1.5", optional = true }
 

--- a/src/auth/ldap.rs
+++ b/src/auth/ldap.rs
@@ -298,17 +298,6 @@ impl LdapAuthenticator {
             include_refresh_payload,
         )
     }
-
-    /// Escape search filters according to RFC 4515. Since all strings in Rust are valid unicode,
-    /// invalid unicode escaping is not done
-    pub fn escape_filter(filter: &str) -> String {
-        filter
-            .replace("\\", "\\5c")
-            .replace("*", "\\2a")
-            .replace("(", "\\28")
-            .replace(")", "\\29")
-            .replace("\x00", "\\00")
-    }
 }
 
 impl super::Authenticator<Basic> for LdapAuthenticator {

--- a/src/auth/ldap.rs
+++ b/src/auth/ldap.rs
@@ -2,13 +2,12 @@
 use std::collections::HashMap;
 
 use ldap3::{LdapConn, Scope, SearchEntry};
+use ldap3::ldap_escape;
 use strfmt::{FmtError, strfmt};
 use serde_json::value;
 
 use {Error, JsonValue, JsonMap};
 use super::{Basic, AuthenticationResult};
-
-const LDAP_SUCCESS: u8 = 0;
 
 /// Error mapping for `FmtError`
 impl From<FmtError> for Error {
@@ -115,19 +114,15 @@ impl LdapAuthenticator {
     /// Bind the connection to some dn
     fn bind(&self, connection: &LdapConn, dn: &str, password: &str) -> Result<(), Error> {
         debug_!("Binding to DN {}", dn);
-        let (result, _) = connection.simple_bind(dn, password)?;
-        if result.rc == LDAP_SUCCESS {
-            Ok(())
-        } else {
-            Err(Error::GenericError(
-                format!("Binding failed with reason code: {}", result.rc),
-            ))
-        }
+        let _s = connection.simple_bind(dn, password)?
+            .success()
+            .map_err(|e| Error::GenericError(format!("Bind failed: {}", e)))?;
+        Ok(())
     }
 
     /// Search for the specified account in the directory
     fn search(&self, connection: &LdapConn, account: &str) -> Result<Vec<SearchEntry>, Error> {
-        let account = Self::escape_filter(account);
+        let account = ldap_escape(account).into();
         let account: HashMap<String, String> = [("account".to_string(), account)].iter().cloned().collect();
         let search_base = strfmt(&self.search_base, &account)?;
         let search_filter = match self.search_filter {
@@ -149,18 +144,12 @@ impl LdapAuthenticator {
             search_attrs_vec
         );
 
-        let (results, status, _) = connection.search(
+        let (results, _) = connection.search(
             &search_base,
             Scope::Subtree,
             &search_filter,
             search_attrs_vec,
-        )?;
-
-        if status.rc != LDAP_SUCCESS {
-            Err(Error::GenericError(
-                format!("Search failed with reason code: {}", status.rc),
-            ))?;
-        }
+        )?.success().map_err(|e| Error::GenericError(format!("Search failed: {}", e)))?;
 
         Ok(results.into_iter().map(SearchEntry::construct).collect())
     }


### PR DESCRIPTION
The ldap3 crate has been recently updated, with a number of breaking changes. As this crate is a reverse dependency, I wanted to see how disruptive the changes were, and port LDAP support to the new version. I also took the opportunity to use the now built-in escaping function. As you can see, the changes are relatively minor, and the new code is a bit more compact and idiomatic.

If you accept the PR, I would also like to link it from ldap3's README as an illustration of 0.4 -> 0.5 porting, if that's OK with you.